### PR TITLE
add console logging to sample

### DIFF
--- a/Func.Isolated.Net7.With.AI/Func.Isolated.Net7.With.AI.csproj
+++ b/Func.Isolated.Net7.With.AI/Func.Isolated.Net7.With.AI.csproj
@@ -15,10 +15,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.11.0-preview2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.0.0-preview3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.8.0-preview2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Func.Isolated.Net7.With.AI/Program.cs
+++ b/Func.Isolated.Net7.With.AI/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Func.Isolated.Net7.With.AI;
+using Microsoft.Extensions.Logging.Console;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults(builder =>
@@ -57,6 +58,13 @@ var host = new HostBuilder()
     {
         // Make sure the configuration of the appsettings.json file is picked up.
         logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+
+        logging.AddSimpleConsole(o =>
+        {
+            o.ColorBehavior = LoggerColorBehavior.Enabled;
+            o.SingleLine = true;
+            o.IncludeScopes = true;
+        });
     })
     .Build();
 

--- a/Func.Isolated.Net7.With.AI/appsettings.json
+++ b/Func.Isolated.Net7.With.AI/appsettings.json
@@ -1,10 +1,21 @@
 ﻿{
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
       "Func.Isolated.Net7.With.AI.MyOtherFunctions": "Error",
       "Func.Isolated.Net7.With.AI.MyUserFunctions": "Debug",
-      "Func.Isolated.Net7.With.AI.UserDataService": "Trace"
+      "Func.Isolated.Net7.With.AI.UserDataService": "Trace",
+      "Azure.Core": "Error",
+      "Default": "Warning"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Func.Isolated.Net7.With.AI.MyOtherFunctions": "Error",
+        "Func.Isolated.Net7.With.AI.MyUserFunctions": "Debug",
+        "Func.Isolated.Net7.With.AI.UserDataService": "Trace",
+        "Func.Isolated.Net7.With.AI": "Information",
+        "Azure.Core": "Error",
+        "Default": "Warning"
+      }
     }
   }
 }

--- a/Func.Isolated.Net7.With.AI/host.json
+++ b/Func.Isolated.Net7.With.AI/host.json
@@ -10,7 +10,11 @@
         "logLevel": {
           "Microsoft": "Warning",
           "Azure.Core": "Error",
-          "Host": "Warning",
+          "Host.Results": "Information",
+          "Host.Executor": "Warning",
+          "Host.General": "Warning",
+          "Host.Controllers.Admin": "Warning",
+          "Host.Aggregator": "Information",
           "default": "Information"
         }
     }

--- a/Func.Isolated.Net7.With.AI/host.json
+++ b/Func.Isolated.Net7.With.AI/host.json
@@ -6,6 +6,12 @@
                 "isEnabled": true,
                 "excludedTypes": "Request"
             }
+        },
+        "logLevel": {
+          "Microsoft": "Warning",
+          "Azure.Core": "Error",
+          "Host": "Warning",
+          "default": "Information"
         }
     }
 }


### PR DESCRIPTION
this adds console logging to the sample, but now there are two entries in ai - one from the console and one from the ai provider - but both can be easily be kept apart